### PR TITLE
Original Legal Entity Id Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-CHANGELOG
+CHANGELOGl
 ---------
+## 13.0.4
+* **Bug Fix** Fix camelcasing issue for original legal entity id
+
 ## 13.0.3
 * **Feature** Changed project structure from .NET Framework to .NET Standard 2.0 (.NET Framework builds will require v4.6.1 or newer).
 * **Bug Fix** Fixed casting error when using app.config

--- a/PayFacMpSDK/PayFacMpSDK/Generated.cs
+++ b/PayFacMpSDK/PayFacMpSDK/Generated.cs
@@ -3613,9 +3613,9 @@ namespace PayFacMpSDK
 
         private string responseDescriptionField;
 
-        private string originallegalEntityIdField;
+        private string originalLegalEntityIdField;
 
-        private string originallegalEntityStatusField;
+        private string originalLegalEntityStatusField;
 
         private backgroundCheckResults backgroundCheckResultsField;
 
@@ -3677,28 +3677,28 @@ namespace PayFacMpSDK
         }
 
         /// <remarks/>
-        public string originallegalEntityId
+        public string originalLegalEntityId
         {
             get
             {
-                return this.originallegalEntityIdField;
+                return this.originalLegalEntityIdField;
             }
             set
             {
-                this.originallegalEntityIdField = value;
+                this.originalLegalEntityIdField = value;
             }
         }
 
         /// <remarks/>
-        public string originallegalEntityStatus
+        public string originalLegalEntityStatus
         {
             get
             {
-                return this.originallegalEntityStatusField;
+                return this.originalLegalEntityStatusField;
             }
             set
             {
-                this.originallegalEntityStatusField = value;
+                this.originalLegalEntityStatusField = value;
             }
         }
 

--- a/PayFacMpSDK/PayFacMpSDK/legalEntityCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDK/legalEntityCreateRequest.cs
@@ -25,8 +25,6 @@ namespace PayFacMpSDK
 
         public legalEntityCreateResponse PostLegalEntityCreateRequest()
         {
-            _configuration.Set("proxyHost", null);
-            _configuration.Set("proxyPort", null);
             string requestBody = this.Serialize();
             var xmlResponse = PayFacUtils.SendPostRequest(ServiceRoute, requestBody, _communication, _configuration);
             return PayFacUtils.DeserializeResponse<legalEntityCreateResponse>(xmlResponse);

--- a/PayFacMpSDK/PayFacMpSDK/legalEntityCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDK/legalEntityCreateRequest.cs
@@ -1,10 +1,6 @@
 ﻿using PayFacMpSDK.Properties;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace PayFacMpSDK
 {
@@ -29,6 +25,8 @@ namespace PayFacMpSDK
 
         public legalEntityCreateResponse PostLegalEntityCreateRequest()
         {
+            _configuration.Set("proxyHost", null);
+            _configuration.Set("proxyPort", null);
             string requestBody = this.Serialize();
             var xmlResponse = PayFacUtils.SendPostRequest(ServiceRoute, requestBody, _communication, _configuration);
             return PayFacUtils.DeserializeResponse<legalEntityCreateResponse>(xmlResponse);

--- a/PayFacMpSDK/PayFacMpSDKTest/Functional/TestLegalEntityCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDKTest/Functional/TestLegalEntityCreateRequest.cs
@@ -9,7 +9,7 @@ namespace PayFacMpSDKTest.Functional
     {
         private legalEntityCreateRequest request;
         private legalEntityCreateResponse response;
-        
+
         [OneTimeSetUp]
         public void setUp()
         {
@@ -29,7 +29,8 @@ namespace PayFacMpSDKTest.Functional
                 contactPhone = "7817659800",
                 annualCreditCardSalesVolume = "80000000",
                 hasAcceptedCreditCards = true,
-                address = new address{
+                address = new address
+                {
                     streetAddress1 = "Street Address 1",
                     streetAddress2 = "Street Address 2",
                     city = "Boston",
@@ -63,8 +64,10 @@ namespace PayFacMpSDKTest.Functional
 
             response = request.PostLegalEntityCreateRequest();
             Assert.NotNull(response.transactionId);
+            Console.WriteLine(response.legalEntityId);
             Assert.NotNull(response.legalEntityId);
             Assert.NotNull(response.principal);
+            Console.WriteLine(response.originalLegalEntityId);
             Assert.AreEqual(10, response.responseCode);
             Assert.AreEqual("Approved", response.responseDescription);
         }
@@ -83,7 +86,8 @@ namespace PayFacMpSDKTest.Functional
                 contactPhone = "7817659800",
                 annualCreditCardSalesVolume = "80000000",
                 hasAcceptedCreditCards = true,
-                address = new address{
+                address = new address
+                {
                     streetAddress1 = "Street Address 1",
                     streetAddress2 = "Street Address 2",
                     city = "Boston",
@@ -114,7 +118,7 @@ namespace PayFacMpSDKTest.Functional
                 },
                 yearsInBusiness = "12"
             };
-            
+
             response = request.PostLegalEntityCreateRequest();
             Assert.NotNull(response.transactionId);
             Assert.NotNull(response.legalEntityId);
@@ -122,8 +126,8 @@ namespace PayFacMpSDKTest.Functional
             Assert.AreEqual(20, response.responseCode);
             Assert.AreEqual("Manual Review", response.responseDescription);
         }
-        
-        
+
+
         [Test]
         public void TestPostLegalEntityCreateRequestDuplicateSimple()
         {
@@ -137,7 +141,8 @@ namespace PayFacMpSDKTest.Functional
                 contactPhone = "7817659800",
                 annualCreditCardSalesVolume = "80000000",
                 hasAcceptedCreditCards = true,
-                address = new address{
+                address = new address
+                {
                     streetAddress1 = "Street Address 1",
                     streetAddress2 = "Street Address 2",
                     city = "Boston",
@@ -168,15 +173,15 @@ namespace PayFacMpSDKTest.Functional
                 },
                 yearsInBusiness = "12"
             };
-            
+
             response = request.PostLegalEntityCreateRequest();
             Assert.AreEqual(true, response.duplicate);
             Assert.NotNull(response.transactionId);
-            Assert.NotNull(response.originallegalEntityId);
-            Assert.AreEqual("Approved", response.originallegalEntityStatus);
+            Assert.NotNull(response.originalLegalEntityId);
+            Assert.AreEqual("Approved", response.originalLegalEntityStatus);
         }
-        
-        
+
+
         [Test]
         public void TestPostLegalEntityCreateRequestDuplicateDeclined()
         {
@@ -190,7 +195,8 @@ namespace PayFacMpSDKTest.Functional
                 contactPhone = "7817659800",
                 annualCreditCardSalesVolume = "80000000",
                 hasAcceptedCreditCards = true,
-                address = new address{
+                address = new address
+                {
                     streetAddress1 = "Street Address 1",
                     streetAddress2 = "Street Address 2",
                     city = "Boston",
@@ -221,12 +227,62 @@ namespace PayFacMpSDKTest.Functional
                 },
                 yearsInBusiness = "12"
             };
-            
+
             response = request.PostLegalEntityCreateRequest();
             Assert.AreEqual(true, response.duplicate);
             Assert.NotNull(response.transactionId);
-            Assert.NotNull(response.originallegalEntityId);
-            Assert.AreEqual("Declined", response.originallegalEntityStatus);
+            Assert.NotNull(response.originalLegalEntityId);
+            Assert.AreEqual("Declined", response.originalLegalEntityStatus);
+        }
+
+        [Test]
+        public void testLegalEntityOriginal()
+        {
+            var request = new legalEntityCreateRequest
+            {
+                legalEntityName = "Yarrgh Pirate Co.",
+                legalEntityType = legalEntityType.LIMITED_LIABILITY_COMPANY,
+                legalEntityOwnershipType = legalEntityOwnershipType.PRIVATE,
+                doingBusinessAs = "Jolly Roger Services",
+                taxId = "551351516",
+                contactPhone = "5555555555",
+                annualCreditCardSalesVolume = "0",
+                hasAcceptedCreditCards = false,
+                address = new address()
+                {
+                    streetAddress1 = "2223 Executive Dr",
+                    city = "Suite 104",
+                    stateProvince = "DT",
+                    postalCode = "48201",
+                    countryCode = "USA"
+                },
+                principal = new legalEntityPrincipal
+                {
+                    firstName = "Joeya",
+                    lastName = "Schmoeya",
+                    emailAddress = "joe2a@example.com",
+                    ssn = "111111113",
+                    contactPhone = "1111111111",
+                    dateOfBirth = (new DateTime(1982, 1, 31)),
+                    address = new principalAddress()
+                    {
+                        streetAddress1 = "900 Chelmsford St",
+                        streetAddress2 = "Ste 5",
+                        city = "Royal Oak",
+                        stateProvince = "MI",
+                        postalCode = "48067",
+                        countryCode = "USA"
+                    },
+                    stakePercent = 100
+                },
+                yearsInBusiness = "0",
+            };
+            var response = request.PostLegalEntityCreateRequest();
+            if (response.legalEntityId == null)
+            {
+                Assert.NotNull(response.originalLegalEntityId);
+                Assert.NotNull(response.originalLegalEntityStatus, null);
+            }
         }
     }
 }

--- a/PayFacMpSDK/PayFacMpSDKTest/Functional/TestLegalEntityCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDKTest/Functional/TestLegalEntityCreateRequest.cs
@@ -64,10 +64,8 @@ namespace PayFacMpSDKTest.Functional
 
             response = request.PostLegalEntityCreateRequest();
             Assert.NotNull(response.transactionId);
-            Console.WriteLine(response.legalEntityId);
             Assert.NotNull(response.legalEntityId);
             Assert.NotNull(response.principal);
-            Console.WriteLine(response.originalLegalEntityId);
             Assert.AreEqual(10, response.responseCode);
             Assert.AreEqual("Approved", response.responseDescription);
         }
@@ -233,56 +231,6 @@ namespace PayFacMpSDKTest.Functional
             Assert.NotNull(response.transactionId);
             Assert.NotNull(response.originalLegalEntityId);
             Assert.AreEqual("Declined", response.originalLegalEntityStatus);
-        }
-
-        [Test]
-        public void testLegalEntityOriginal()
-        {
-            var request = new legalEntityCreateRequest
-            {
-                legalEntityName = "Yarrgh Pirate Co.",
-                legalEntityType = legalEntityType.LIMITED_LIABILITY_COMPANY,
-                legalEntityOwnershipType = legalEntityOwnershipType.PRIVATE,
-                doingBusinessAs = "Jolly Roger Services",
-                taxId = "551351516",
-                contactPhone = "5555555555",
-                annualCreditCardSalesVolume = "0",
-                hasAcceptedCreditCards = false,
-                address = new address()
-                {
-                    streetAddress1 = "2223 Executive Dr",
-                    city = "Suite 104",
-                    stateProvince = "DT",
-                    postalCode = "48201",
-                    countryCode = "USA"
-                },
-                principal = new legalEntityPrincipal
-                {
-                    firstName = "Joeya",
-                    lastName = "Schmoeya",
-                    emailAddress = "joe2a@example.com",
-                    ssn = "111111113",
-                    contactPhone = "1111111111",
-                    dateOfBirth = (new DateTime(1982, 1, 31)),
-                    address = new principalAddress()
-                    {
-                        streetAddress1 = "900 Chelmsford St",
-                        streetAddress2 = "Ste 5",
-                        city = "Royal Oak",
-                        stateProvince = "MI",
-                        postalCode = "48067",
-                        countryCode = "USA"
-                    },
-                    stakePercent = 100
-                },
-                yearsInBusiness = "0",
-            };
-            var response = request.PostLegalEntityCreateRequest();
-            if (response.legalEntityId == null)
-            {
-                Assert.NotNull(response.originalLegalEntityId);
-                Assert.NotNull(response.originalLegalEntityStatus, null);
-            }
         }
     }
 }


### PR DESCRIPTION
The goal of this change is to fix a bug in camelcasing that was causing originalLegalEntityId to not be deserialized from the response correctly