### PR TITLE
Update to v13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-CHANGELOGl
+CHANGELOG
 ---------
+
+## 13.1.0
+* **Feature** Support for Payfac MP API v13.1
+
 ## 13.0.4
 * **Bug Fix** Fix camelcasing issue for original legal entity id
 

--- a/PayFacMpSDK/PayFacMpSDK/Generated.cs
+++ b/PayFacMpSDK/PayFacMpSDK/Generated.cs
@@ -3338,6 +3338,10 @@ namespace PayFacMpSDK
 
         private string yearsInBusinessField;
 
+        private string sdkVersionField;
+
+        private string languageField;
+
         /// <remarks/>
         public string legalEntityName
         {
@@ -3478,6 +3482,33 @@ namespace PayFacMpSDK
             set
             {
                 this.yearsInBusinessField = value;
+            }
+        }
+
+        public string sdkVersion
+        {
+            get
+            {
+                return this.sdkVersionField;
+                
+            }
+            set
+            {
+                this.sdkVersionField = value;
+            }
+        }
+
+        public string language
+        {
+            get
+            {
+                return this.language;
+                
+            }
+            set
+            {
+                this.languageField = value;
+                
             }
         }
     }
@@ -4178,6 +4209,10 @@ namespace PayFacMpSDK
 
         private legalEntityPrincipal principalField;
 
+        private string sdkVersionField;
+
+        private string languageField;
+
         /// <remarks/>
         public legalEntityPrincipal principal
         {
@@ -4188,6 +4223,33 @@ namespace PayFacMpSDK
             set
             {
                 this.principalField = value;
+            }
+        }
+        
+        public string sdkVersion
+        {
+            get
+            {
+                return this.sdkVersionField;
+                
+            }
+            set
+            {
+                this.sdkVersionField = value;
+            }
+        }
+
+        public string language
+        {
+            get
+            {
+                return this.language;
+                
+            }
+            set
+            {
+                this.languageField = value;
+                
             }
         }
     }
@@ -4511,6 +4573,10 @@ namespace PayFacMpSDK
 
         private string settlementCurrencyField;
 
+        private string sdkVersionField;
+
+        private string languageField;
+
         /// <remarks/>
         public string merchantName
         {
@@ -4809,6 +4875,33 @@ namespace PayFacMpSDK
             set
             {
                 this.settlementCurrencyField = value;
+            }
+        }
+        
+        public string sdkVersion
+        {
+            get
+            {
+                return this.sdkVersionField;
+                
+            }
+            set
+            {
+                this.sdkVersionField = value;
+            }
+        }
+
+        public string language
+        {
+            get
+            {
+                return this.language;
+                
+            }
+            set
+            {
+                this.languageField = value;
+                
             }
         }
     }
@@ -5627,6 +5720,10 @@ namespace PayFacMpSDK
 
         private legalEntityAgreement legalEntityAgreementField;
 
+        private string sdkVersionField;
+
+        private string languageField;
+
         /// <remarks/>
         public legalEntityAgreement legalEntityAgreement
         {
@@ -5637,6 +5734,33 @@ namespace PayFacMpSDK
             set
             {
                 this.legalEntityAgreementField = value;
+            }
+        }
+        
+        public string sdkVersion
+        {
+            get
+            {
+                return this.sdkVersionField;
+                
+            }
+            set
+            {
+                this.sdkVersionField = value;
+            }
+        }
+
+        public string language
+        {
+            get
+            {
+                return this.language;
+                
+            }
+            set
+            {
+                this.languageField = value;
+                
             }
         }
     }

--- a/PayFacMpSDK/PayFacMpSDK/PayFacMpSDK.csproj
+++ b/PayFacMpSDK/PayFacMpSDK/PayFacMpSDK.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <PackageVersion>13.0.4</PackageVersion>
+        <PackageVersion>13.1.0</PackageVersion>
         <Title>Vantiv.PayFacMpSdkForNet</Title>
         <Authors>Worldpay</Authors>
         <Copyright>Copyright © Worldpay 2020</Copyright>
@@ -10,7 +10,7 @@
         <PackageId>Vantiv.PayFacMpSdkForNet</PackageId>
         <Description>The PayFac Merchant Provisioner SDK is a C# implementation of the Worldpay PayFac Merchant Provisioner API. This SDK was created to make it as easy as possible to perform operations that allows you to create and update Legal Entities and Sub-merchants, as well as retrieve information about existing Legal Entities and Sub-merchants in near real-time. This SDK utilizes the HTTPS protocol to securely connect to Worldpay. Using the SDK requires coordination with the Vantiv eCommerce team in order to be provided with credentials for accessing our systems.
 
-Each .NET SDK release supports all of the functionality present in the associated PayFac Merchant Provisioner API version (e.g., SDK v13.0.0 supports API v13.0.0). Please see our documentation for PayFac Merchant Provisioner API to get more details on what operations are supported.
+Each .NET SDK release supports all of the functionality present in the associated PayFac Merchant Provisioner API version (e.g., SDK v13.1.0 supports API v13.1.0). Please see our documentation for PayFac Merchant Provisioner API to get more details on what operations are supported.
 
 This SDK is implemented to support the .NET plaform, including C#, VB.NET and Managed C++ and is created by Worldpay. Its intended use is for PayFac API operations with Worldpay.</Description>
         <PackageProjectUrl>https://github.com/Vantiv/payfac-mp-sdk-dotnet</PackageProjectUrl>

--- a/PayFacMpSDK/PayFacMpSDK/PayFacUtils.cs
+++ b/PayFacMpSDK/PayFacMpSDK/PayFacUtils.cs
@@ -14,8 +14,8 @@ namespace PayFacMpSDK
     public class PayFacUtils
     {
 
-        private const string CONTENT_TYPE = "application/com.vantivcnp.payfac-v13+xml";
-        private const string ACCEPT = "application/com.vantivcnp.payfac-v13+xml";
+        private const string CONTENT_TYPE = "application/com.vantivcnp.payfac-v13.1+xml";
+        private const string ACCEPT = "application/com.vantivcnp.payfac-v13.1+xml";
 
         public static string BytesToString(List<byte> bytes)
         {
@@ -138,7 +138,7 @@ namespace PayFacMpSDK
             var webErrorResponse = (HttpWebResponse) we.Response;
             var httpStatusCode = (int) webErrorResponse.StatusCode;
             var rawResponse = GetResponseXml(webErrorResponse);
-            if (!webErrorResponse.ContentType.Contains("application/com.vantivcnp.payfac-v13+xml"))
+            if (!webErrorResponse.ContentType.Contains("application/com.vantivcnp.payfac-v13.1+xml"))
                 return new PayFacWebException(string.Format("Request Failed - HTTP {0} Error", httpStatusCode)
                     , httpStatusCode, rawResponse);
             PrintXml(rawResponse, config.Get("printxml"), config.Get("neuterXml"));

--- a/PayFacMpSDK/PayFacMpSDK/Versions.cs
+++ b/PayFacMpSDK/PayFacMpSDK/Versions.cs
@@ -1,0 +1,8 @@
+namespace PayFacMpSDK
+{
+    public class Versions
+    {
+        public static string SDK_VERSION = "13.0.0";
+        public static string LANGUAGE = "dotnet";
+    }
+}

--- a/PayFacMpSDK/PayFacMpSDK/Versions.cs
+++ b/PayFacMpSDK/PayFacMpSDK/Versions.cs
@@ -2,7 +2,7 @@ namespace PayFacMpSDK
 {
     public class Versions
     {
-        public static string SDK_VERSION = "13.0.0";
+        public static string SDK_VERSION = "13.1.0";
         public static string LANGUAGE = "dotnet";
     }
 }

--- a/PayFacMpSDK/PayFacMpSDK/legalEntityAgreementCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDK/legalEntityAgreementCreateRequest.cs
@@ -42,6 +42,8 @@ namespace PayFacMpSDK
             xmlBuilder.Append("<legalEntityAgreement>");
             legalEntityAgreement.Serialize(xmlBuilder);
             xmlBuilder.Append("</legalEntityAgreement>");
+            xmlBuilder.Append("<sdkVersion>" + Versions.SDK_VERSION + "</sdkVersion>");
+            xmlBuilder.Append("<language>" + Versions.LANGUAGE + "</language>");
             xmlBuilder.Append("</legalEntityAgreementCreateRequest>");
             Console.WriteLine(xmlBuilder.ToString());
             return xmlBuilder.ToString();

--- a/PayFacMpSDK/PayFacMpSDK/legalEntityCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDK/legalEntityCreateRequest.cs
@@ -50,6 +50,8 @@ namespace PayFacMpSDK
             principal.Serialize(xmlBuilder);
             xmlBuilder.Append("</principal>");
             if(yearsInBusiness != null) xmlBuilder.Append("<yearsInBusiness>" + yearsInBusiness + "</yearsInBusiness>");
+            xmlBuilder.Append("<sdkVersion>" + Versions.SDK_VERSION + "</sdkVersion>");
+            xmlBuilder.Append("<language>" + Versions.LANGUAGE + "</language>");
             xmlBuilder.Append("</legalEntityCreateRequest>");
             Console.WriteLine(xmlBuilder.ToString());
             return xmlBuilder.ToString();

--- a/PayFacMpSDK/PayFacMpSDK/legalEntityPrincipalCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDK/legalEntityPrincipalCreateRequest.cs
@@ -42,6 +42,8 @@ namespace PayFacMpSDK
             xmlBuilder.Append("<principal>");
             principal.Serialize(xmlBuilder);
             xmlBuilder.Append("</principal>");
+            xmlBuilder.Append("<sdkVersion>" + Versions.SDK_VERSION + "</sdkVersion>");
+            xmlBuilder.Append("<language>" + Versions.LANGUAGE + "</language>");
             xmlBuilder.Append("</legalEntityPrincipalCreateRequest>");
             Console.WriteLine(xmlBuilder.ToString());
             return xmlBuilder.ToString();

--- a/PayFacMpSDK/PayFacMpSDK/subMerchantCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDK/subMerchantCreateRequest.cs
@@ -81,6 +81,8 @@ namespace PayFacMpSDK
                 xmlBuilder.Append("</subMerchantFunding>");
             }
             xmlBuilder.Append("<settlementCurrency>" + settlementCurrency + "</settlementCurrency>");
+            xmlBuilder.Append("<sdkVersion>" + Versions.SDK_VERSION + "</sdkVersion>");
+            xmlBuilder.Append("<language>" + Versions.LANGUAGE + "</language>");
             xmlBuilder.Append("</subMerchantCreateRequest>");
             Console.WriteLine(xmlBuilder.ToString());
             return xmlBuilder.ToString();

--- a/PayFacMpSDK/PayFacMpSDKTest/Functional/TestCommunication.cs
+++ b/PayFacMpSDK/PayFacMpSDKTest/Functional/TestCommunication.cs
@@ -20,8 +20,8 @@ namespace PayFacMpSDKTest.Functional
             _communication = new Communication();
             _config = new Configuration();
             _communication.SetAuth(_config.Get("username"), _config.Get("password"));
-            _communication.SetContentType("application/com.vantivcnp.payfac-v13+xml");
-            _communication.SetAccept("application/com.vantivcnp.payfac-v13+xml");
+            _communication.SetContentType("application/com.vantivcnp.payfac-v13.1+xml");
+            _communication.SetAccept("application/com.vantivcnp.payfac-v13.1+xml");
             _communication.SetHost(_config.Get("url"));
             _communication.SetProxy(_config.Get("proxyHost"), _config.Get("proxyPort"));
         }

--- a/PayFacMpSDK/PayFacMpSDKTest/Unit/TestLegalEntityAgreementCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDKTest/Unit/TestLegalEntityAgreementCreateRequest.cs
@@ -47,6 +47,8 @@ namespace PayFacMpSDKTest.Unit
         "<manuallyEntered>true</manuallyEntered>" +
         "<acceptanceDateTime>" + DateTime.Now.ToString("yyyy-MM-ddThh:mm:sszzz") + "</acceptanceDateTime>" +
         "</legalEntityAgreement>" +
+        "<sdkVersion>" + Versions.SDK_VERSION + "</sdkVersion>" +
+        "<language>" + Versions.LANGUAGE + "</language>" + 
         "</legalEntityAgreementCreateRequest>";
 
             string expectedResposne = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +

--- a/PayFacMpSDK/PayFacMpSDKTest/Unit/TestLegalEntityCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDKTest/Unit/TestLegalEntityCreateRequest.cs
@@ -66,44 +66,46 @@ namespace PayFacMpSDKTest.Unit
         {
 
             var xmlReq = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-        "<legalEntityCreateRequest xmlns=\"http://payfac.vantivcnp.com/api/merchant/onboard\">" +
-        "<legalEntityName>Legal Entity Name</legalEntityName>" +
-        "<legalEntityType>CORPORATION</legalEntityType>" +
-        "<legalEntityOwnershipType>PUBLIC</legalEntityOwnershipType>" +
-        "<doingBusinessAs>Alternate Business Name</doingBusinessAs>" +
-        "<taxId>123456789</taxId>" +
-        "<contactPhone>7817659800</contactPhone>" +
-        "<annualCreditCardSalesVolume>80000000</annualCreditCardSalesVolume>" +
-        "<hasAcceptedCreditCards>true</hasAcceptedCreditCards>" +
-        "<address>" +
-        "<streetAddress1>Street Address 1</streetAddress1>" +
-        "<streetAddress2>Street Address 2</streetAddress2>" +
-        "<city>Boston</city>" +
-        "<stateProvince>MA</stateProvince>" +
-        "<postalCode>01730</postalCode>" +
-        "<countryCode>USA</countryCode>" +
-        "</address>" +
-        "<principal>" +
-        "<title>Chief Financial Officer</title>" +
-        "<firstName>p first</firstName>" +
-        "<lastName>p last</lastName>" +
-        "<emailAddress>abc@email.com</emailAddress>" +
-        "<ssn>123459876</ssn>" +
-        "<contactPhone>7817659800</contactPhone>" +
-        "<dateOfBirth>1980-10-12</dateOfBirth>" +
-        "<driversLicense>892327409832</driversLicense>" +
-        "<address>" +
-        "<streetAddress1>p street address 1</streetAddress1>" +
-        "<streetAddress2>p street address 2</streetAddress2>" +
-        "<city>Boston</city>" +
-        "<stateProvince>MA</stateProvince>" +
-        "<postalCode>01890</postalCode>" +
-        "<countryCode>USA</countryCode>" +
-        "</address>" +
-        "<stakePercent>33</stakePercent>" +
-        "</principal>" +
-        "<yearsInBusiness>12</yearsInBusiness>" +
-        "</legalEntityCreateRequest>";
+                         "<legalEntityCreateRequest xmlns=\"http://payfac.vantivcnp.com/api/merchant/onboard\">" +
+                         "<legalEntityName>Legal Entity Name</legalEntityName>" +
+                         "<legalEntityType>CORPORATION</legalEntityType>" +
+                         "<legalEntityOwnershipType>PUBLIC</legalEntityOwnershipType>" +
+                         "<doingBusinessAs>Alternate Business Name</doingBusinessAs>" +
+                         "<taxId>123456789</taxId>" +
+                         "<contactPhone>7817659800</contactPhone>" +
+                         "<annualCreditCardSalesVolume>80000000</annualCreditCardSalesVolume>" +
+                         "<hasAcceptedCreditCards>true</hasAcceptedCreditCards>" +
+                         "<address>" +
+                         "<streetAddress1>Street Address 1</streetAddress1>" +
+                         "<streetAddress2>Street Address 2</streetAddress2>" +
+                         "<city>Boston</city>" +
+                         "<stateProvince>MA</stateProvince>" +
+                         "<postalCode>01730</postalCode>" +
+                         "<countryCode>USA</countryCode>" +
+                         "</address>" +
+                         "<principal>" +
+                         "<title>Chief Financial Officer</title>" +
+                         "<firstName>p first</firstName>" +
+                         "<lastName>p last</lastName>" +
+                         "<emailAddress>abc@email.com</emailAddress>" +
+                         "<ssn>123459876</ssn>" +
+                         "<contactPhone>7817659800</contactPhone>" +
+                         "<dateOfBirth>1980-10-12</dateOfBirth>" +
+                         "<driversLicense>892327409832</driversLicense>" +
+                         "<address>" +
+                         "<streetAddress1>p street address 1</streetAddress1>" +
+                         "<streetAddress2>p street address 2</streetAddress2>" +
+                         "<city>Boston</city>" +
+                         "<stateProvince>MA</stateProvince>" +
+                         "<postalCode>01890</postalCode>" +
+                         "<countryCode>USA</countryCode>" +
+                         "</address>" +
+                         "<stakePercent>33</stakePercent>" +
+                         "</principal>" +
+                         "<yearsInBusiness>12</yearsInBusiness>" +
+                         "<sdkVersion>" + Versions.SDK_VERSION + "</sdkVersion>" +
+                         "<language>" + Versions.LANGUAGE + "</language>" + 
+                         "</legalEntityCreateRequest>";
 
             string expectedResposne = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
         "<legalEntityCreateResponse xmlns=\"http://payfac.vantivcnp.com/api/merchant/onboard\">" +

--- a/PayFacMpSDK/PayFacMpSDKTest/Unit/TestLegalEntityPrincipalCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDKTest/Unit/TestLegalEntityPrincipalCreateRequest.cs
@@ -63,6 +63,8 @@ namespace PayFacMpSDKTest.Unit
                          "</address>" +
                          "<stakePercent>31</stakePercent>" +
                          "</principal>" +
+                         "<sdkVersion>" + Versions.SDK_VERSION + "</sdkVersion>" +
+                         "<language>" + Versions.LANGUAGE + "</language>" + 
                          "</legalEntityPrincipalCreateRequest>";
             
             var expectedResponse = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +

--- a/PayFacMpSDK/PayFacMpSDKTest/Unit/TestSubMerchantCreateRequest.cs
+++ b/PayFacMpSDK/PayFacMpSDKTest/Unit/TestSubMerchantCreateRequest.cs
@@ -112,6 +112,8 @@ namespace PayFacMpSDKTest.Unit
         "<subMerchantFunding enabled =\"false\">" +
         "</subMerchantFunding>" +
         "<settlementCurrency>USD</settlementCurrency>" +
+        "<sdkVersion>" + Versions.SDK_VERSION + "</sdkVersion>" +
+        "<language>" + Versions.LANGUAGE + "</language>" + 
         "</subMerchantCreateRequest>";
 
             string expectedResposne = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +


### PR DESCRIPTION
The goal of this change is to update Payfac SDK to v13.1. The new schema includes 2 new optional elements, sdkVersion and language, in each create request. These are automatically set to help us capture sdk usage, and no action is required on the part of the end user. 